### PR TITLE
Fix orphan channel cleanup

### DIFF
--- a/mensetsu.py
+++ b/mensetsu.py
@@ -980,19 +980,34 @@ async def delete_candidate_channels(
     progress_key = make_progress_key(guild.id, candidate_id)
 
     # ---------- テキストチャンネル削除 ----------
-    for ch in guild.text_channels:
-        if data_manager.interview_channel_mapping.get(ch.id) == progress_key:
+    cp = data_manager.candidate_progress.get(progress_key)
+    text_channel_id: Optional[int] = None
+    if cp:
+        text_channel_id = cp.get("channel_id")
+
+    if text_channel_id:
+        ch = guild.get_channel(text_channel_id)
+        if isinstance(ch, discord.TextChannel):
             try:
                 await ch.delete()
                 logger.info(f"候補者 {candidate_id} のテキストチャンネル {ch.id} を削除")
             except Exception as e:
                 logger.error(f"テキストチャンネル {ch.id} 削除失敗: {e}")
             data_manager.interview_channel_mapping.pop(ch.id, None)
-            break
+    else:
+        # mapping から検索して削除
+        for ch in guild.text_channels:
+            if data_manager.interview_channel_mapping.get(ch.id) == progress_key:
+                try:
+                    await ch.delete()
+                    logger.info(f"候補者 {candidate_id} のテキストチャンネル {ch.id} を削除")
+                except Exception as e:
+                    logger.error(f"テキストチャンネル {ch.id} 削除失敗: {e}")
+                data_manager.interview_channel_mapping.pop(ch.id, None)
+                break
 
     # ---------- VC 削除 ----------
     # 1) cp 由来の voice_channel_id
-    cp = data_manager.candidate_progress.get(progress_key)
     vc_candidates: list[int] = []
     if cp and cp.get("voice_channel_id"):
         vc_candidates.append(cp["voice_channel_id"])
@@ -2959,6 +2974,7 @@ class TaskCog(commands.Cog):
         self.bot = bot
         self.check_candidate_status.start()
         self.schedule_notifications.start()
+        self.cleanup_orphan_channels.start()
 
     @tasks.loop(minutes=5)
     async def check_candidate_status(self) -> None:
@@ -3063,6 +3079,32 @@ class TaskCog(commands.Cog):
                     cp['notified_candidate'] = False
                     cp['notified_interviewer'] = False
                     await data_manager.save_data()
+
+    # ---------- 定期クリーンアップ ----------
+    @tasks.loop(minutes=10)
+    async def cleanup_orphan_channels(self) -> None:
+        for progress_key, cp in list(data_manager.candidate_progress.items()):
+            guild_id = cp.get('source_guild_id', MAIN_GUILD_ID)
+            guild = self.bot.get_guild(guild_id)
+            if guild is None:
+                continue
+            candidate_id = cp.get('candidate_id')
+            if candidate_id is None:
+                continue
+            if guild.get_member(candidate_id):
+                continue
+            try:
+                await delete_candidate_channels(self.bot, guild, candidate_id)
+            except Exception as e:
+                logger.error(f"孤立チャンネル削除失敗: {e}")
+            data_manager.candidate_progress.pop(progress_key, None)
+            await data_manager.save_data()
+            request_dashboard_update(self.bot)
+            logger.info(f"候補者 {candidate_id} の進捗を削除しました (退出検知失敗)")
+
+    @cleanup_orphan_channels.before_loop
+    async def _before_cleanup_orphan_channels(self) -> None:
+        await self.bot.wait_until_ready()
 # ------------------------------------------------
 # DelayedActionManager（遅延アクション管理）
 # ------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure deletion uses stored channel_id fallback
- periodically clean up stale candidate data when members have already left

## Testing
- `python -m py_compile mensetsu.py`

------
https://chatgpt.com/codex/tasks/task_e_68540d2b5eac8325b76f10c28d91e82e